### PR TITLE
disable rocker saving

### DIFF
--- a/rockerc/rockerc.py
+++ b/rockerc/rockerc.py
@@ -144,8 +144,9 @@ def run_rockerc(path: str = "."):
         cmd = f"rocker {cmd_args}"
         print(f"running cmd: {cmd}")
         split_cmd = shlex.split(cmd)
-        save_rocker_cmd(split_cmd)
-        subprocess.run(split_cmd, check=True)
+        # save_rocker_cmd(split_cmd)
+        subprocess.call(cmd, shell=True)
+        # subprocess.run(split_cmd, check=False)
     else:
         print(
             "no arguments found in rockerc.yaml. Please add rocker arguments as described in rocker -h:"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Disable the saving of rocker commands by commenting out the save_rocker_cmd function call.