### PR TITLE
reduce updates to weekly and remove black

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,11 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: monthly
     groups:
       dev-dependencies:
         #try to group all development dependencies updates into a single pr
         patterns:          
-          - "black"
           - "check-manifest"
           - "pre-commit"
           - "pylint"


### PR DESCRIPTION
## Summary by Sourcery

Update the dependabot configuration to check for updates monthly instead of weekly and remove black from the dev-dependencies group.

Enhancements:
- Remove black from the development dependencies group.

CI:
- Update the dependency update schedule from weekly to monthly.