### PR TITLE
Feature/default extensions

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -35,7 +35,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/95/42aa2156235cbc8fa61208aded06ef46111c4d3f0de233107b3f38631803/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a2/77/8c6d22bf61921a59bce5471c2f1f7ac30cd4ac50aadde72b8c48d5727902/coverage-7.10.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a7/7a/8b98967da1ee547cb917687f02b02c16ef025ab294ab26bb5a04d8d35302/deps_rocker-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/81/32098dd6956a4f841dab7ab8032e8e2454258494499eb81b27a76fc00f04/deps_rocker-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl
@@ -105,7 +105,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/1a/7425c952944a6521a9cfa7e675343f83fd82085b8af2b1373a2409c683dc/charset_normalizer-3.4.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/19/20/d0384ac06a6f908783d9b6aa6135e41b093971499ec488e47279f5b846e6/coverage-7.10.7-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a7/7a/8b98967da1ee547cb917687f02b02c16ef025ab294ab26bb5a04d8d35302/deps_rocker-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/81/32098dd6956a4f841dab7ab8032e8e2454258494499eb81b27a76fc00f04/deps_rocker-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl
@@ -178,7 +178,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/df/b7737ff046c974b183ea9aa111b74185ac8c3a326c6262d413bd5a1b8c69/charset_normalizer-3.4.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b0/ef/bd8e719c2f7417ba03239052e099b76ea1130ac0cbb183ee1fcaa58aaff3/coverage-7.10.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a7/7a/8b98967da1ee547cb917687f02b02c16ef025ab294ab26bb5a04d8d35302/deps_rocker-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/81/32098dd6956a4f841dab7ab8032e8e2454258494499eb81b27a76fc00f04/deps_rocker-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl
@@ -248,7 +248,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/ab/0233c3231af734f5dfcf0844aa9582d5a1466c985bbed6cedab85af9bfe3/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/90/a64aaacab3b37a17aaedd83e8000142561a29eb262cede42d94a67f7556b/coverage-7.10.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a7/7a/8b98967da1ee547cb917687f02b02c16ef025ab294ab26bb5a04d8d35302/deps_rocker-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/81/32098dd6956a4f841dab7ab8032e8e2454258494499eb81b27a76fc00f04/deps_rocker-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl
@@ -317,7 +317,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/95/42aa2156235cbc8fa61208aded06ef46111c4d3f0de233107b3f38631803/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a2/77/8c6d22bf61921a59bce5471c2f1f7ac30cd4ac50aadde72b8c48d5727902/coverage-7.10.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a7/7a/8b98967da1ee547cb917687f02b02c16ef025ab294ab26bb5a04d8d35302/deps_rocker-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/81/32098dd6956a4f841dab7ab8032e8e2454258494499eb81b27a76fc00f04/deps_rocker-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl
@@ -504,10 +504,10 @@ packages:
   requires_dist:
   - tomli ; python_full_version <= '3.11' and extra == 'toml'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/a7/7a/8b98967da1ee547cb917687f02b02c16ef025ab294ab26bb5a04d8d35302/deps_rocker-0.13.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/18/81/32098dd6956a4f841dab7ab8032e8e2454258494499eb81b27a76fc00f04/deps_rocker-0.14.0-py3-none-any.whl
   name: deps-rocker
-  version: 0.13.0
-  sha256: c92c472dd69ceda5ba74ce0949076539178ae7023db3679305564f2b6876d418
+  version: 0.14.0
+  sha256: 27dbdce4f2a3bffdd3ab7e0d87eca8b5315e396cefbaaab47ff1f3d691b8c503
   requires_dist:
   - off-your-rocker>=0.1.0
   - pyyaml>=5.0
@@ -1118,10 +1118,10 @@ packages:
 - pypi: ./
   name: rockerc
   version: 0.11.0
-  sha256: a2d4acc665d72443af0eaa11ad52fa6b165f1e4939f9032a751fbb8e89fd572a
+  sha256: 62a8f0cd1e442d1bc2bf0b1407db94dbcce2311e95b7fcb119bda202dff51dd8
   requires_dist:
-  - rocker>=0.2.17
-  - deps-rocker>=0.11
+  - rocker>=0.2.19
+  - deps-rocker>=0.14
   - off-your-rocker>=0.1.0
   - pyyaml>=5
   - pylint>=3.2.5,<=3.3.8 ; extra == 'test'
@@ -1131,11 +1131,8 @@ packages:
   - ruff>=0.5.0,<=0.13.2 ; extra == 'test'
   - coverage>=7.5.4,<=7.10.7 ; extra == 'test'
   - pre-commit<=4.2.0 ; extra == 'test'
-  - palanteer-rocker>=0.0.1 ; extra == 'extensions'
-  - lazygit-rocker>=0.0.1 ; extra == 'extensions'
   - ghrocker==0.0.10 ; extra == 'extensions'
   - groot-rocker==0.4.1 ; extra == 'extensions'
-  - cargo-rocker==0.0.3 ; extra == 'extensions'
   editable: true
 - pypi: https://files.pythonhosted.org/packages/64/8b/e87cfca2be6f8b9f41f0bb12dc48c6455e2d66df46fe61bb441a226f1089/ruff-0.13.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: ruff

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -1,6 +1,10 @@
 from unittest import TestCase
 import pytest
-from rockerc.rockerc import yaml_dict_to_args, collect_arguments
+import tempfile
+import pathlib
+import yaml
+from unittest.mock import patch
+from rockerc.rockerc import yaml_dict_to_args, collect_arguments, deduplicate_extensions, load_global_config
 
 
 class TestBasicClass(TestCase):
@@ -12,7 +16,7 @@ class TestBasicClass(TestCase):
             "option1": "value1",
             "option2": "value2",
         }
-        expected = "--x11 --nvidia --option1 value1 --option2 value2 ubuntu:latest"
+        expected = "--x11 --nvidia --option1 value1 --option2 value2 -- ubuntu:latest"
         result = yaml_dict_to_args(d)
         assert result == expected
 
@@ -28,7 +32,29 @@ class TestBasicClass(TestCase):
             "image": "ubuntu:22.04",
         }
 
-        expected = "--nvidia --x11 --user --pull --deps --git ubuntu:22.04"
+        expected = "--nvidia --x11 --user --pull --deps --git -- ubuntu:22.04"
+
+        result = yaml_dict_to_args(d)
+        assert result == expected
+
+    def test_no_optional_arg_extensions(self):
+        d = {
+            "args": ["nvidia", "x11", "user", "pull", "git"],
+            "image": "ubuntu:22.04",
+        }
+
+        expected = "--nvidia --x11 --user --pull --git -- ubuntu:22.04"
+
+        result = yaml_dict_to_args(d)
+        assert result == expected
+
+    def test_only_optional_arg_extensions(self):
+        d = {
+            "args": ["deps"],
+            "image": "ubuntu:22.04",
+        }
+
+        expected = "--deps -- ubuntu:22.04"
 
         result = yaml_dict_to_args(d)
         assert result == expected
@@ -43,3 +69,121 @@ class TestBasicClass(TestCase):
         }
 
         assert result == expected
+
+    def test_deduplicate_extensions(self):
+        extensions = ["nvidia", "x11", "user", "nvidia", "git", "x11"]
+        expected = ["nvidia", "x11", "user", "git"]
+        result = deduplicate_extensions(extensions)
+        assert result == expected
+
+    def test_deduplicate_extensions_empty(self):
+        extensions = []
+        expected = []
+        result = deduplicate_extensions(extensions)
+        assert result == expected
+
+    def test_deduplicate_extensions_no_duplicates(self):
+        extensions = ["nvidia", "x11", "user"]
+        expected = ["nvidia", "x11", "user"]
+        result = deduplicate_extensions(extensions)
+        assert result == expected
+
+    def test_load_global_config_no_file(self):
+        with patch('pathlib.Path.home') as mock_home:
+            mock_home.return_value = pathlib.Path("/nonexistent")
+            result = load_global_config()
+            assert result == {}
+
+    def test_load_global_config_with_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = pathlib.Path(tmpdir) / ".rockerc.yaml"
+            config_data = {"args": ["codex", "vim"]}
+            with open(config_path, "w") as f:
+                yaml.dump(config_data, f)
+
+            with patch('pathlib.Path.home') as mock_home:
+                mock_home.return_value = pathlib.Path(tmpdir)
+                result = load_global_config()
+                assert result == config_data
+
+    def test_collect_arguments_with_global_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create global config with image and args
+            global_config_path = pathlib.Path(tmpdir) / ".rockerc.yaml"
+            global_config = {"args": ["codex", "vim"], "image": "ubuntu:20.04"}
+            with open(global_config_path, "w") as f:
+                yaml.dump(global_config, f)
+
+            # Create project config that overrides image
+            project_dir = pathlib.Path(tmpdir) / "project"
+            project_dir.mkdir()
+            project_config_path = project_dir / "rockerc.yaml"
+            project_config = {"args": ["nvidia", "x11"], "image": "ubuntu:22.04"}
+            with open(project_config_path, "w") as f:
+                yaml.dump(project_config, f)
+
+            with patch('pathlib.Path.home') as mock_home:
+                mock_home.return_value = pathlib.Path(tmpdir)
+                result = collect_arguments(str(project_dir))
+
+                # Global extensions should come first, then project extensions, deduplicated
+                # Project image should override global image
+                expected = {
+                    "args": ["codex", "vim", "nvidia", "x11"],
+                    "image": "ubuntu:22.04"
+                }
+                assert result == expected
+
+    def test_collect_arguments_global_image_only(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create global config with image and args
+            global_config_path = pathlib.Path(tmpdir) / ".rockerc.yaml"
+            global_config = {"args": ["codex", "vim"], "image": "ubuntu:20.04"}
+            with open(global_config_path, "w") as f:
+                yaml.dump(global_config, f)
+
+            # Create project config without image
+            project_dir = pathlib.Path(tmpdir) / "project"
+            project_dir.mkdir()
+            project_config_path = project_dir / "rockerc.yaml"
+            project_config = {"args": ["nvidia", "x11"]}
+            with open(project_config_path, "w") as f:
+                yaml.dump(project_config, f)
+
+            with patch('pathlib.Path.home') as mock_home:
+                mock_home.return_value = pathlib.Path(tmpdir)
+                result = collect_arguments(str(project_dir))
+
+                # Should use global image when project doesn't specify one
+                expected = {
+                    "args": ["codex", "vim", "nvidia", "x11"],
+                    "image": "ubuntu:20.04"
+                }
+                assert result == expected
+
+    def test_collect_arguments_with_duplicate_extensions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create global config with overlapping extensions
+            global_config_path = pathlib.Path(tmpdir) / ".rockerc.yaml"
+            global_config = {"args": ["codex", "nvidia", "vim"]}
+            with open(global_config_path, "w") as f:
+                yaml.dump(global_config, f)
+
+            # Create project config with some same extensions
+            project_dir = pathlib.Path(tmpdir) / "project"
+            project_dir.mkdir()
+            project_config_path = project_dir / "rockerc.yaml"
+            project_config = {"args": ["nvidia", "x11", "codex"], "image": "ubuntu:22.04"}
+            with open(project_config_path, "w") as f:
+                yaml.dump(project_config, f)
+
+            with patch('pathlib.Path.home') as mock_home:
+                mock_home.return_value = pathlib.Path(tmpdir)
+                result = collect_arguments(str(project_dir))
+
+                # Should be deduplicated, preserving order (global first, then new from project)
+                expected = {
+                    "args": ["codex", "nvidia", "vim", "x11"],
+                    "image": "ubuntu:22.04"
+                }
+                assert result == expected

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -59,6 +59,18 @@ class TestBasicClass(TestCase):
         result = yaml_dict_to_args(d)
         assert result == expected
 
+    def test_with_extra_args(self):
+        d = {
+            "args": ["nvidia", "x11"],
+            "image": "ubuntu:22.04",
+        }
+        extra_args = "--image-name test --name container"
+
+        expected = "--nvidia --x11 --image-name test --name container -- ubuntu:22.04"
+
+        result = yaml_dict_to_args(d, extra_args)
+        assert result == expected
+
     @pytest.mark.skip
     def test_realisic_yaml(self):
         result = collect_arguments(".")


### PR DESCRIPTION
## Summary by Sourcery

Enable global configuration loading, extension deduplication, and enhanced argument generation for rocker commands.

New Features:
- Load default arguments and image from a global ~/.rockerc.yaml via load_global_config
- Introduce deduplicate_extensions to remove duplicate extensions while preserving order
- Allow passing extra command-line arguments into yaml_dict_to_args before the image
- Merge global and project-specific configurations in collect_arguments with args deduplication

Enhancements:
- Always insert a "--" separator before the image in generated argument strings
- Refactor run_rockerc to assemble extra_args and forward them to yaml_dict_to_args

Tests:
- Add tests for yaml_dict_to_args handling of extra_args and separator
- Add tests for deduplicate_extensions
- Add tests for load_global_config behavior with and without config files
- Add tests for collect_arguments merging logic and deduplication across global and project configs