### PR TITLE
depend on deps-rocker detach to avoid off-your-rocker string escape i…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rockerc"
-version = "0.11.0"
+version = "0.12.0"
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A tool to parse rockerc.yaml files and pass on the arguments onto rocker"
 readme = "README.md"
@@ -8,8 +8,7 @@ license = "MIT"
 
 dependencies = [
   "rocker>=0.2.19",
-  "deps-rocker>=0.14",
-  "off-your-rocker>=0.1.0",
+  "deps-rocker>=0.15",
   "pyyaml>=5",
 ]
 

--- a/rockerc/rockervsc.py
+++ b/rockerc/rockervsc.py
@@ -21,7 +21,7 @@ def folder_to_vscode_container(container_name: str, path: Path) -> Tuple[str, st
     """
 
     container_hex = binascii.hexlify(container_name.encode()).decode()
-    rocker_args = f"--image-name {container_name} --name {container_name} --volume {path}:/workspaces/{container_name}:Z --oyr-run-arg '\" --detach\"'"
+    rocker_args = f"--image-name {container_name} --name {container_name} --volume {path}:/workspaces/{container_name}:Z --detach"
 
     return container_hex, rocker_args
 

--- a/test/compose/rockerc.yaml
+++ b/test/compose/rockerc.yaml
@@ -9,5 +9,4 @@ image: ubuntu:22.04
 image-name: '"$CONTAINER_NAME"'
 name: '"$CONTAINER_NAME"'
 volume: '"${PWD}":/workspaces/"${CONTAINER_NAME}":Z'
-oyr-run-arg: '" --detach"'
  

--- a/test/test_vscode_launcher.py
+++ b/test/test_vscode_launcher.py
@@ -15,7 +15,7 @@ class TestFolderToVscodeContainer:
         assert container_hex == expected_hex
         assert (
             rocker_args
-            == "--image-name test_container --name test_container --volume /some/path:/workspaces/test_container:Z --oyr-run-arg '\" --detach\"'"
+            == "--image-name test_container --name test_container --volume /some/path:/workspaces/test_container:Z --detach"
         )
 
     # Handles empty container name string
@@ -26,9 +26,7 @@ class TestFolderToVscodeContainer:
         container_hex, rocker_args = folder_to_vscode_container(container_name, path)
 
         expected_hex = ""
-        expected_rocker_args = (
-            "--image-name  --name  --volume /some/path:/workspaces/:Z --oyr-run-arg '\" --detach\"'"
-        )
+        expected_rocker_args = "--image-name  --name  --volume /some/path:/workspaces/:Z --detach"
 
         assert container_hex == expected_hex
         assert rocker_args == expected_rocker_args


### PR DESCRIPTION
…ssues

## Summary by Sourcery

Simplify the detach flag handling by removing the string-escaping dependency and switch to the native --detach option, bumping the project version and dependencies accordingly and updating tests and sample config.

Enhancements:
- Replace the quoted --oyr-run-arg detach workaround with a native --detach flag in folder_to_vscode_container
- Remove the off-your-rocker dependency and rely on updated deps-rocker for detach support

Build:
- Bump project version to 0.12.0
- Update deps-rocker requirement to >=0.15 and drop off-your-rocker

Tests:
- Update test_vscode_launcher.py to expect --detach instead of the oyr-run-arg escape
- Remove the obsolete oyr-run-arg entry from the sample rockerc.yaml