### PR TITLE
Feature/target dir bug

### DIFF
--- a/rockerc/renv.py
+++ b/rockerc/renv.py
@@ -835,8 +835,8 @@ def manage_container(  # pylint: disable=too-many-positional-arguments,too-many-
                 if ret != 0:
                     return ret
 
-            # Restore working directory before attach operations
-            os.chdir(original_cwd)
+            # Change to branch_dir for docker exec operations (must be in mounted directory)
+            os.chdir(branch_dir)
 
             # Wait for container to be ready
             if not wait_for_container(container_name):
@@ -860,8 +860,8 @@ def manage_container(  # pylint: disable=too-many-positional-arguments,too-many-
             exists = False
 
         if exists:
-            # Restore cwd before attaching
-            os.chdir(original_cwd)
+            # Change to branch_dir for docker exec operations (must be in mounted directory)
+            os.chdir(branch_dir)
 
             # Container already running, attach to it
             if command:

--- a/rockerc/renv.py
+++ b/rockerc/renv.py
@@ -633,6 +633,9 @@ def run_rocker_command(
 
     # Add named parameters (but skip special ones we handle separately)
     for key, value in config.items():
+        # Skip internal markers (keys starting with underscore) and special keys
+        if key.startswith("_"):
+            continue
         if key not in ["image", "args", "volume", "oyr-run-arg"]:
             cmd_parts.extend([f"--{key}", str(value)])
 

--- a/specs/11/target-dir-bug/plan.md
+++ b/specs/11/target-dir-bug/plan.md
@@ -1,0 +1,24 @@
+# Implementation Plan
+
+## Overview
+Prevent internal configuration markers (like `_renv_target_dir`) from being passed to rocker as command-line arguments.
+
+## Steps
+
+1. **Modify `run_rocker_command` function**
+   - Add filtering logic to skip keys starting with underscore when building rocker command arguments
+   - This prevents internal markers from being passed to rocker
+
+2. **Test the fix**
+   - Run existing tests to ensure no regressions
+   - Verify container corruption handling works correctly
+
+3. **Run CI**
+   - Execute `pixi run ci`
+   - Fix any failures
+   - Iterate until passing
+
+## Technical Notes
+- Keys starting with underscore are reserved for internal use within renv
+- The `_renv_target_dir` is popped from config in the normal flow (line 799) but not in the corruption handling path
+- By filtering underscored keys in `run_rocker_command`, we make it robust against future additions of internal markers

--- a/specs/11/target-dir-bug/spec.md
+++ b/specs/11/target-dir-bug/spec.md
@@ -1,0 +1,12 @@
+# Fix _renv_target_dir being passed to rocker
+
+## Problem
+When container corruption is detected, `renv` passes `--_renv_target_dir` to rocker, which doesn't recognize this argument, causing the command to fail with "unrecognized arguments: --_renv_target_dir".
+
+## Root Cause
+In `_handle_container_corruption` (renv.py:742-743), the config dict containing `_renv_target_dir` is passed directly to `run_rocker_command` without removing this internal marker first.
+
+`_renv_target_dir` is an internal configuration value used by renv to track the target directory for `os.chdir()` before launching containers. It should never be passed to rocker.
+
+## Solution
+Filter out keys starting with underscore in `run_rocker_command` when building rocker arguments, as these are internal markers not meant for rocker.


### PR DESCRIPTION
## Summary by Sourcery

Filter internal configuration markers from rocker command arguments and switch to the branch directory before docker exec to prevent unrecognized-argument and container breakout errors

Bug Fixes:
- Skip config keys starting with underscore in run_rocker_command to avoid passing internal flags like _renv_target_dir to rocker
- Change working directory to branch_dir before docker exec operations to ensure the target path is mounted and avoid breakout detection failures

Chores:
- Add implementation plan and spec documentation for the target-dir bug fix under specs/11