### PR TITLE
Feature/parse cli extensions and image

### DIFF
--- a/rockerc.deps.yaml
+++ b/rockerc.deps.yaml
@@ -1,10 +1,6 @@
 apt_tools:
-  - git
-  - git-lfs
   - python3-pip
   - jq #for auto installing extensions in container
 
 pip_language-toolchain:
-  - uv #use uv instead of pip
-  - pip #update to the latest pip
   - pre-commit

--- a/rockerc.yaml
+++ b/rockerc.yaml
@@ -9,7 +9,6 @@ image: ubuntu:22.04
 # dockerfile: .devcontainer/Dockerfile
 # dockerfile: Dockerfile
 args:
-  - nvidia
   - x11 
   - user 
   - pull 
@@ -17,3 +16,4 @@ args:
   - git 
   - pixi
   - cwd
+  - uv

--- a/specs/13/cli-extension-image-parsing/plan.md
+++ b/specs/13/cli-extension-image-parsing/plan.md
@@ -1,0 +1,46 @@
+# Implementation Plan
+
+## 1. Add `parse_cli_extensions_and_image()` function
+
+```python
+def parse_cli_extensions_and_image(args: list[str]) -> tuple[list[str], str | None, list[str]]:
+    """Parse CLI arguments into extensions, image, and command.
+
+    Returns: (extensions, image, command)
+
+    Examples:
+        ['--claude', 'ubuntu:22.04'] -> (['claude'], 'ubuntu:22.04', [])
+        ['--user', '--git', 'ubuntu:22.04', 'bash'] -> (['user', 'git'], 'ubuntu:22.04', ['bash'])
+        ['ubuntu:22.04'] -> ([], 'ubuntu:22.04', [])
+    """
+```
+
+Logic:
+- Iterate through args
+- If arg starts with `--`, extract extension name and add to extensions list
+- First non-flag arg is the image
+- Remaining args are command
+
+## 2. Update `run_rockerc()` workflow
+
+```python
+# Parse CLI args
+cli_extensions, cli_image, cli_command = parse_cli_extensions_and_image(filtered_cli)
+
+# Merge CLI extensions with config extensions
+if cli_extensions:
+    merged_dict["args"] = deduplicate_extensions(merged_dict.get("args", []) + cli_extensions)
+
+# Override image if provided
+if cli_image:
+    merged_dict["image"] = cli_image
+
+# Pass command through as extra_cli for injection
+extra_cli = " ".join(cli_command) if cli_command else ""
+```
+
+## 3. Testing approach
+- Test with various CLI argument combinations
+- Ensure backward compatibility (no args, flags only, etc.)
+- Verify image override works
+- Verify extension merging works

--- a/specs/13/cli-extension-image-parsing/spec.md
+++ b/specs/13/cli-extension-image-parsing/spec.md
@@ -1,0 +1,32 @@
+# Parse CLI extensions and image arguments
+
+## Problem
+Running `rockerc --claude ubuntu:22.04` produces a broken rocker command:
+```
+rocker ... --cwd --claude ubuntu:22.04 --detach ... -- ubuntu:24.04
+```
+
+Issues:
+1. Image appears twice (`ubuntu:22.04` from CLI, `ubuntu:24.04` from config)
+2. CLI args are passed through unparsed, causing rocker to misinterpret them
+3. No way to override config image via CLI
+
+## Solution
+Parse CLI arguments to separate:
+- Extension flags: `--extension-name`
+- Image: first non-flag argument
+- Command: remaining arguments after image
+
+## Behavior
+```bash
+rockerc --claude ubuntu:22.04           # Use claude extension, override image
+rockerc --user --git                     # Add extensions to config
+rockerc ubuntu:22.04                     # Override image only
+rockerc ubuntu:22.04 bash -c "echo hi"   # Override image with command
+```
+
+## Implementation
+- Add `parse_cli_extensions_and_image()` function
+- Returns: (extensions: list[str], image: str|None, command: list[str])
+- Merge CLI extensions with config extensions
+- CLI image overrides config image if provided


### PR DESCRIPTION
## Summary by Sourcery

Enable users to specify and override container extensions, image, and runtime commands directly via CLI by parsing flags before invoking the rocker command, while updating dependencies and adding design documentation.

New Features:
- Add parse_cli_extensions_and_image to extract extension flags, image, and command from CLI arguments
- Allow overriding the default image and merging custom extensions via CLI in run_rockerc

Enhancements:
- Integrate extension and image parsing into run_rockerc to deduplicate merged args, apply image overrides, and pass through command arguments
- Remove unused dependencies (git, git-lfs, uv, pip) from rockerc.deps.yaml and update default config to include 'uv' extension

Documentation:
- Introduce implementation plan and specification documents for CLI extension and image parsing functionality