### PR TITLE
Feature/configurable renv home

### DIFF
--- a/specs/16/configurable-renv-home/plan.md
+++ b/specs/16/configurable-renv-home/plan.md
@@ -1,0 +1,5 @@
+- Locate all uses of the hardcoded `~/renv` path across the codebase.
+- Introduce a shared helper (likely in `rockerc/renv.py`) that expands `RENV_DIR` or defaults to `~/renv`.
+- Refactor modules and scripts to depend on the helper.
+- Patch tests to set `RENV_DIR=/tmp/renv`, clean up temporary data between runs if needed.
+- Run `pixi run ci` and address any failures.

--- a/specs/16/configurable-renv-home/spec.md
+++ b/specs/16/configurable-renv-home/spec.md
@@ -1,0 +1,5 @@
+# Configurable RENV home
+
+- Add a helper that returns the renv home, reading `RENV_DIR` when set and defaulting to `~/renv`.
+- Update runtime code to use the helper instead of hardcoding paths.
+- Ensure tests isolate state by setting `RENV_DIR` to `/tmp/renv`.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,38 @@
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+_TEST_RENV_DIR = Path("/tmp/renv")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_renv_dir():
+    """Force tests to use an isolated renv directory under /tmp."""
+
+    previous = os.environ.get("RENV_DIR")
+
+    if _TEST_RENV_DIR.exists():
+        shutil.rmtree(_TEST_RENV_DIR)
+    _TEST_RENV_DIR.mkdir(parents=True, exist_ok=True)
+
+    os.environ["RENV_DIR"] = str(_TEST_RENV_DIR)
+
+    try:
+        yield _TEST_RENV_DIR
+    finally:
+        if previous is None:
+            os.environ.pop("RENV_DIR", None)
+        else:
+            os.environ["RENV_DIR"] = previous
+        shutil.rmtree(_TEST_RENV_DIR, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
+def ensure_renv_dir_exists():
+    """Make sure the renv directory exists before each test."""
+
+    _TEST_RENV_DIR.mkdir(parents=True, exist_ok=True)
+    yield

--- a/test/workflows/test_workflow_0_fresh_container.sh
+++ b/test/workflows/test_workflow_0_fresh_container.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
-rm -rf ~/renv
+
+RENV_DIR="${RENV_DIR:-$HOME/renv}"
+rm -rf "${RENV_DIR}"
 # Remove all containers with test_renv in the name
 docker ps -a --format '{{.Names}}' | grep 'test_renv' | xargs -r docker rm -f
 cd /tmp

--- a/test/workflows/test_workflow_11_container_breakout.sh
+++ b/test/workflows/test_workflow_11_container_breakout.sh
@@ -2,16 +2,18 @@
 #!/usr/bin/env bash
 set -e
 
+RENV_DIR="${RENV_DIR:-$HOME/renv}"
+
 echo "Step 1: Run renv blooop/test_renv pwd (should build and run container)"
 renv blooop/test_renv pwd
 
-echo "Step 2: Delete ~/renv directory"
-rm -rf ~/renv
-if [ -d ~/renv ]; then
-    echo "ERROR: ~/renv directory still exists after rm -rf"
+echo "Step 2: Delete ${RENV_DIR} directory"
+rm -rf "${RENV_DIR}"
+if [ -d "${RENV_DIR}" ]; then
+    echo "ERROR: ${RENV_DIR} directory still exists after rm -rf"
     exit 1
 fi
-echo "✓ ~/renv deleted"
+echo "✓ ${RENV_DIR} deleted"
 
 echo "Step 3: Run renv blooop/test_renv pwd again (should detect breakout and rebuild)"
 renv blooop/test_renv pwd

--- a/test/workflows/test_workflow_3_force_rebuild.sh
+++ b/test/workflows/test_workflow_3_force_rebuild.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -e
+
+RENV_DIR="${RENV_DIR:-$HOME/renv}"
+
 cd /tmp
 
 docker container stop test_renv-main 2>/dev/null || echo "Container test_renv-main not running"
-docker run --rm -v ~/renv:/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
-rm -rf ~/renv
+docker run --rm -v "${RENV_DIR}":/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
+rm -rf "${RENV_DIR}"
 echo "Testing force rebuild after renv dir deletion..."
 renv --force blooop/test_renv git status
 echo "✓ Force rebuild test completed"

--- a/test/workflows/test_workflow_4_container_breakout.sh
+++ b/test/workflows/test_workflow_4_container_breakout.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 set -e
+
+RENV_DIR="${RENV_DIR:-$HOME/renv}"
+
 cd /tmp
 
 docker container stop test_renv-main 2>/dev/null || echo "Container test_renv-main not running"
 docker rm -f test_renv-main 2>/dev/null || echo "Container test_renv-main not found"
-docker run --rm -v ~/renv:/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
-rm -rf ~/renv
+docker run --rm -v "${RENV_DIR}":/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
+rm -rf "${RENV_DIR}"
 renv blooop/test_renv echo "Container started successfully"
-docker run --rm -v ~/renv:/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
-rm -rf ~/renv
+docker run --rm -v "${RENV_DIR}":/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
+rm -rf "${RENV_DIR}"
 echo "Testing renv after deleting directory with running container..."
 renv blooop/test_renv git status
 echo "✓ Container breakout detection test completed"

--- a/test/workflows/test_workflow_5_basic_lifecycle.sh
+++ b/test/workflows/test_workflow_5_basic_lifecycle.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
-rm -rf ~/renv
+
+RENV_DIR="${RENV_DIR:-$HOME/renv}"
+
+rm -rf "${RENV_DIR}"
 cd /tmp
 
 echo "=== BASIC CONTAINER LIFECYCLE TEST ==="
@@ -34,8 +37,8 @@ echo "=== TEST 4: FORCE REBUILD AFTER CORRUPTION ==="
 # Stop the container first to avoid permission issues
 docker container stop test_renv-main 2>/dev/null || echo "Container test_renv-main not running"
 # Use docker to change permissions first, then remove
-docker run --rm -v ~/renv:/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
-rm -rf ~/renv
+docker run --rm -v "${RENV_DIR}":/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
+rm -rf "${RENV_DIR}"
 echo "Testing force rebuild after renv dir deletion..."
 renv --force blooop/test_renv git status
 echo "✓ Force rebuild test completed"
@@ -45,13 +48,13 @@ echo "=== TEST 5: CONTAINER BREAKOUT DETECTION ==="
 # First create a fresh container
 docker container stop test_renv-main 2>/dev/null || echo "Container test_renv-main not running"
 docker rm -f test_renv-main 2>/dev/null || echo "Container test_renv-main not found"
-docker run --rm -v ~/renv:/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
-rm -rf ~/renv
+docker run --rm -v "${RENV_DIR}":/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
+rm -rf "${RENV_DIR}"
 # Start fresh container
 renv blooop/test_renv echo "Container started successfully"
 # Now delete renv directory while container is running
-docker run --rm -v ~/renv:/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
-rm -rf ~/renv
+docker run --rm -v "${RENV_DIR}":/renv ubuntu:22.04 chmod -R 777 /renv 2>/dev/null || echo "No renv directory to chmod"
+rm -rf "${RENV_DIR}"
 echo "Testing renv after deleting directory with running container..."
 # This should detect the issue and fix it
 renv blooop/test_renv git status


### PR DESCRIPTION
## Summary by Sourcery

Allow customizing the renv home directory via the RENV_DIR environment variable and replace all hardcoded ~/renv references with a shared helper, updating shell completion, tests, and scripts accordingly.

New Features:
- Support RENV_DIR environment variable to configure the renv home directory.
- Add get_renv_root helper to determine renv root using RENV_DIR or default to ~/renv.

Enhancements:
- Refactor code and shell completion to use get_renv_root instead of hardcoded ~/renv.

Tests:
- Add pytest fixtures to set and isolate RENV_DIR for tests.
- Update bash workflow scripts to reference RENV_DIR instead of ~/renv.

Chores:
- Include plan and spec markdown files for the configurable renv home feature.